### PR TITLE
fix issue with requiring module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/vue-select');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/Haixing-Hu/vue-select/issues"
   },
   "main": [
-    "src/vue-select.js"
+    "index.js"
   ],
   "configs": {
     "directories": {


### PR DESCRIPTION
Seems like after installing the module, I couldn't use it doing things like "import VueSelect from 'vue-select2'".
After making these few changes, i'm not getting the error anymore.

Maybe there is a better way to fix it but I thought I'd propose that anyway :)
