### PR TITLE
Require on vue 1.x needs a change in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "bugs": {
     "url": "https://github.com/Haixing-Hu/vue-select/issues"
   },
-  "main": [
-    "src/vue-select.js"
-  ],
+  "main": "src/vue-select.js",
   "configs": {
     "directories": {
       "dist": "dist",


### PR DESCRIPTION
Please see this issue. I've just implemented the chagne suggested and confirm it has worked
https://github.com/Haixing-Hu/vue-select/issues/2
